### PR TITLE
fix(deps): bump SQLitePCLRaw.lib.e_sqlite3 to 3.50.3 (GHSA-2m69-gcr7-jv3q)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.85" />
     <PackageVersion Include="Photino.Blazor" Version="4.0.13" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/McpManager.Desktop/McpManager.Desktop.csproj
+++ b/src/McpManager.Desktop/McpManager.Desktop.csproj
@@ -25,6 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\McpManager.Core\McpManager.Core.csproj" />

--- a/src/McpManager.Infrastructure/McpManager.Infrastructure.csproj
+++ b/src/McpManager.Infrastructure/McpManager.Infrastructure.csproj
@@ -10,6 +10,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/McpManager.Web/McpManager.Web.csproj
+++ b/src/McpManager.Web/McpManager.Web.csproj
@@ -10,6 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "inherit": false,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
## Summary

- Pins `SQLitePCLRaw.lib.e_sqlite3` to **3.50.3** (patched) via Central Package Management
- Adds explicit `PackageReference` to `McpManager.Desktop`, `McpManager.Infrastructure`, and `McpManager.Web` to force the override over the vulnerable 2.1.11 transitive pin from `Microsoft.EntityFrameworkCore.Sqlite`
- Resolves 3 open Dependabot alerts for GHSA-2m69-gcr7-jv3q

## Test plan
- [x] `dotnet restore` — no NU1903 warnings
- [x] `dotnet build` — 0 errors, pre-existing warnings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)