### PR TITLE
fix(ci): use fetch-depth 0 so Nerdbank.GitVersioning can compute version height

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "inherit": false,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
Co-Authored-By: Claude <noreply@anthropic.com>
