### PR TITLE
fix(ci): install playwright deps for screenshot capture

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -24,7 +24,15 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Install Playwright
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Node dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: Build application

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "inherit": false,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
The capture-screenshots.mjs script imports the 'playwright' npm package,
but the workflow never installed node dependencies before running it,
causing ERR_MODULE_NOT_FOUND. Add a Node setup + npm install step, and
run the Playwright browser install after deps are present.

Co-Authored-By: Claude <noreply@anthropic.com>
